### PR TITLE
Update README.md for Scala 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ configuration with a Play Framework application.
 ```sbtshell
 resolvers += "jitpack" at "https://jitpack.io"
 
-libraryDependencies += "com.github.play-rconf" %% "play-rconf" % "release~YY.MM"
+libraryDependencies += "com.github.play-rconf" % "play-rconf" % "release~YY.MM"
 ```
 
 


### PR DESCRIPTION
We need to use a single `%` on library dependency over SBT because JitPack doesn't build using Scala Cross Version.

BTW, @thibaultmeyer I think we can update this README to explain how to use one of the Providers to help others (or even publish the providers over JitPack as well).