### PR TITLE
Fix remote configuration won't override local configuration (Scala)

### DIFF
--- a/src/main/scala/io/playrconf/ApplicationLoaderScala.scala
+++ b/src/main/scala/io/playrconf/ApplicationLoaderScala.scala
@@ -64,9 +64,9 @@ class ApplicationLoaderScala extends GuiceApplicationLoader {
       .disableCircularProxies()
       .in(context.environment)
       .loadConfig(
-        localConfiguration withFallback Configuration.apply(
+        Configuration.apply(
           this.processAllProviders(localConfiguration.underlying)
-        )
+        ) withFallback localConfiguration
       )
       .overrides(overrides(context): _*)
   }


### PR DESCRIPTION
This problem is introduced by commit 158ee4, which simply replaced the deprecated ++ method with withFallback method, even though these two methods don't have the same semantics.

Resolves: #9
